### PR TITLE
pyproject.toml: replace tabs with spaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,11 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = """
     -n auto
-	--cov-branch
-	--cov-report term
-	--cov-report html
-	--cov-report xml
-	--cov=<MODULE_NAME>
+    --cov-branch
+    --cov-report term
+    --cov-report html
+    --cov-report xml
+    --cov=<MODULE_NAME>
 """
 python_files = "test_*.py"
 testpaths = "tests"


### PR DESCRIPTION
With the tabs I was getting this error:

    $ pip install -e .[dev]
    Obtaining file://.../src/eip712
    ERROR: Exception:
    Traceback (most recent call last):
      ...
      File ".../eip712_env/lib/python3.8/site-packages/pip/_internal/pyproject.py", line 75, in load_pyproject_toml
        pp_toml = pytoml.load(f)
      File ".../eip712_env/share/python-wheels/__pytoml-0.1.21-py2.py3-none-any.whl/pytoml/parser.py", line 11, in load
        return loads(fin.read(), translate=translate, object_pairs_hook=object_pairs_hook, filename=getattr(fin, 'name', repr(fin)))
      File ".../eip712_env/share/python-wheels/__pytoml-0.1.21-py2.py3-none-any.whl/pytoml/parser.py", line 24, in loads
        ast = _p_toml(src, object_pairs_hook=object_pairs_hook)
      File ".../eip712_env/share/python-wheels/__pytoml-0.1.21-py2.py3-none-any.whl/pytoml/parser.py", line 341, in _p_toml
        s.expect_eof()
      File ".../eip712_env/share/python-wheels/__pytoml-0.1.21-py2.py3-none-any.whl/pytoml/parser.py", line 123, in expect_eof
        return self._expect(self.consume_eof())
      File ".../eip712_env/share/python-wheels/__pytoml-0.1.21-py2.py3-none-any.whl/pytoml/parser.py", line 163, in _expect
        raise TomlError('msg', self._pos[0], self._pos[1], self._filename)
    pytoml.core.TomlError: .../src/eip712/pyproject.toml(33, 1): msg