### PR TITLE
pre-commit: bump isort version to the latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     -   id: seed-isort-config
 
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.8.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
I want to use isort:off and isort:on to disable isort when it conflicts with black's autoformatting.

https://pycqa.github.io/isort/docs/configuration/action_comments/#isort-off

Without something like this you can get into a situation where during `pre-commit` isort will make one set of changes, and black will undo the change. Adding a `# isort: skip` comment to the line will let you workaround this in some cases, but you can't use that when there's already a comment on the import line (e.g. for flake8 or mypy).