### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report an error that you've encountered.
+---
+### Environment information
+
+* `ape` and plugin versions:
+
+```
+$ ape --version
+# ...copy and paste result of above command here...
+
+$ ape plugins list
+# ...copy and paste result of above command here...
+```
+
+* Python Version: x.x.x
+* OS: osx/linux/win
+
+### What went wrong?
+
+Please include information like:
+
+* what command you ran
+* the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
+* full output of the error you received
+
+### How can it be fixed?
+
+Fill this in if you have ideas on how the bug could be fixed.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Request a new feature, or an improvement to existing functionality.
+---
+
+### Overview
+
+Provide a simple overview of what you wish to see added. Please include:
+
+* What you are trying to do
+* Why Ape's current functionality is inadequate to address your goal
+
+### Specification
+
+Describe the syntax and semantics of how you would like to see this feature implemented. The more detailed the better!
+
+Remember, your feature is much more likely to be included if it does not involve any breaking changes.
+
+### Dependencies
+
+Include links to any open issues that must be resolved before this feature can be implemented.

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,0 +1,43 @@
+---
+name: Work item
+about: New work item for Ape team
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Elevator pitch:
+<!-- 1-2 line summary of the scope of this work item -->
+
+### Value:
+<!--
+  Who is this for?
+  Persona or group of people whom will derive value from the scenario.
+  What benefits will be achieved or business metrics improved?
+-->
+
+### Dependencies:
+<!-- Call out key people, teams, tech dependencies, or assumptions. -->
+
+### Design approach:
+<!--
+  Free text / diagram / whiteboard picture / etc. that clearly shows your approach and considerations to build the task list.
+  Existing code patterns in production code base that you will base your work off of.
+-->
+
+### Task list:
+<!-- Bulleted list describing the exit criteria, desired end state and any documentation, monitors, work for DRI, etc. that will need to be added to make sure someone else can support once it's live. -->
+* [ ] Tasks go here
+
+### Estimated completion date:
+
+
+### Design review:
+<!-- 1-2 people needed for signoff -->
+Do not signoff unless:
+- 1) agreed the tasks and design approach will achieve acceptance, and
+- 2) the work can be completed by one person within the SLA.
+Design reviewers should consider simpler approaches to achieve goals.
+
+(Please leave a comment to sign off)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### What I did
+
+Related issue: #
+
+### How I did it
+
+### How to verify it
+
+### Checklist
+
+- [ ] Passes all linting checks (pre-commit and CI jobs)
+- [ ] New test cases have been added and are passing
+- [ ] Documentation has been updated
+- [ ] Commit messages and PR title follow [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)


### PR DESCRIPTION
* The `work-item` template comes from eip712. This is the format we talked about for doing sprint planning.
* The `bug` and `feature` templates are copied from brownie (updated for ape specifics).
* Same goes for the pull request template