### PR TITLE
feat: upgrade black, mypy, and isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.10b0
     hooks:
       - id: black
         name: black
@@ -26,9 +26,10 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.910-1
     hooks:
     -   id: mypy
+        additional_dependencies: [types-PyYAML, types-requests]
 
 
 default_language_version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "<MODULE_NAME>/version.py"
 
@@ -11,7 +14,7 @@ write_to = "<MODULE_NAME>/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -32,6 +35,7 @@ exclude = '''
 [tool.pytest.ini_options]
 addopts = """
     -n auto
+    -p no:ape_test"
     --cov-branch
     --cov-report term
     --cov-report html


### PR DESCRIPTION
### What I did

mypy and isort would fail with the current template, this fixes that.
also upgrades black

### How I did it

copy ape and other plugins

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
