### PR TITLE
fix: remove duplicate mypy pyproject.toml entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,3 @@ known_third_party = ["hypothesis"]
 known_first_party = ["MODULE_NAME"]
 multi_line_output = 3
 use_parentheses = true
-
-[tool.mypy]
-exclude = "build"


### PR DESCRIPTION
### What I did

This part is already present at the top of the file and causes error when listed twice, so just removing it here.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
